### PR TITLE
Annotate the fun iptables match

### DIFF
--- a/client/wg0.conf
+++ b/client/wg0.conf
@@ -7,6 +7,9 @@ Table = 1234
 PostUp = ip rule add fwmark 1234 table 1234
 PostUp = ip rule add ipproto udp dport 53 table 1234
 PostUp = ip rule add ipproto tcp dport 53 table 1234
+# `\! -f` to match only head fragments / unfragmented packets
+# `-m u32 --u32 "0>>22&0x3C@5&0xF0=0xC0:0xE0"` tests that first byte of UDP payload matches a QUIC long header packet
+# See `man iptables-extensions 8` under `MATCH EXTENSIONS`
 PostUp = iptables -A OUTPUT -t mangle -p udp --dport 443 \! -f -m u32 --u32 "0>>22&0x3C@5&0xF0=0xC0:0xE0" -j MARK --set-mark 1234
 PreDown = ip rule del fwmark 1234 table 1234
 PreDown = ip rule del ipproto udp dport 53 table 1234


### PR DESCRIPTION
Hi! I recently read through and enjoyed the QUICstep paper. Congratulations on publishing! The implementation here is very impressively clean and concise, but I also had to do some reading to sort out the specifics of the `iptables` rule.

I had a bit of doing so, but perhaps others would appreciate a comment or two clarifying this particular bit? Or perhaps in the README? Just a thought! :)

(Sorry, the missing newline in the diff is what I get for editing directly in Github...)